### PR TITLE
Forward declare sqlite3.h (modular framework)

### DIFF
--- a/RNBackgroundGeolocation/TSLocationManager.framework/Headers/LocationDAO.h
+++ b/RNBackgroundGeolocation/TSLocationManager.framework/Headers/LocationDAO.h
@@ -6,8 +6,9 @@
 //  Copyright (c) 2015 Transistor Software. All rights reserved.
 //
 #import <Foundation/Foundation.h>
-#import <sqlite3.h>
 #import <CoreLocation/CoreLocation.h>
+
+typedef struct sqlite3 sqlite3;
 
 @interface LocationDAO : NSObject
 {


### PR DESCRIPTION
Allows ReactNativeBackgroundGeolocation to be built as a framework itself