### PR TITLE
Remove listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,18 @@
 # Change Log
+## [Unreleased]
+- [Changed] Implement a mechanism for removing listeners `removeListener` (@alias `un`).  This is particularly important for Android when using `stopOnTerminate: false`.  Listeners on `BackgroundGeolocation` should be removed in `componentDidUnmount`:
+```Javascript
+  componentDidMount() {
+    BackgroundGeolocation.on('location', this.onLocation);
+  }
+  onLocation(location) {
+    console.log('- Location: ', location);
+  }
+  componentDidUnmount() {
+    BackgroundGeolocation.un('location', this.onLocation);
+  }
+```
+
 ## [1.5.1] - 2016-10-17
 - [Fixed] Bug in `stopDetectionDelay` logic
 - [Fixed] Geofencing transistion event logging wouldn't occur when configured for `debug: false`

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ import BackgroundGeolocation from "react-native-background-geolocation";
 import BackgroundGeolocation from "react-native-background-geolocation";
 
 var Foo = React.createClass({
-  getInitialState() {
-    
+  componentWillMount() {
+
     BackgroundGeolocation.configure({
       // Geolocation Config
       desiredAccuracy: 0,
@@ -67,7 +67,6 @@ var Foo = React.createClass({
       url: 'http://posttestserver.com/post.php?dir=cordova-background-geolocation',
       batchSync: false,       // <-- [Default: false] Set true to sync locations to server in a single HTTP request.
       autoSync: true,         // <-- [Default: true] Set true to sync each location to server as it arrives.
-      maxDaysToPersist: 1,    // <-- Maximum days to persist a location in plugin's SQLite database when HTTP fails
       headers: {              // <-- Optional HTTP headers
         "X-FOO": "bar"
       },
@@ -76,40 +75,53 @@ var Foo = React.createClass({
       }
     }, function(state) {
       console.log("- BackgroundGeolocation is configured and ready: ", state.enabled);
-      
+
       if (!state.enabled) {
         BackgroundGeolocation.start(function() {
           console.log("- Start success");
         });
       }
     });
-    
+
     // This handler fires whenever bgGeo receives a location update.
-    BackgroundGeolocation.on('location', function(location) {
-      console.log('- [js]location: ', JSON.stringify(location));
-    });
-    
+    BackgroundGeolocation.on('location', this.onLocation);
+
     // This handler fires whenever bgGeo receives an error
-    BackgroundGeolocation.on('error', function(error) {
-      var type = error.type;
-      var code = error.code;
-      alert(type + " Error: " + code);
-    });
+    BackgroundGeolocation.on('error', this.onError);
 
     // This handler fires when movement states changes (stationary->moving; moving->stationary)
-    BackgroundGeolocation.on('motionchange', function(location) {
-        console.log('- [js]motionchanged: ', JSON.stringify(location));
-    });
-    
+    BackgroundGeolocation.on('motionchange', this.onMotionChange);
+
     // This event fires when a chnage in motion activity is detected
-    BackgroundGeolocation.on('activitychange', function(activityName) {
-      console.log('- Current motion activity: ', activityName);  // eg: 'on_foot', 'still', 'in_vehicle'
-    });
-    
+    BackgroundGeolocation.on('activitychange', this.onActivityChange);
+
     // This event fires when the user toggles location-services
-    BackgroundGeolocation.on('providerchange', function(provider) {
-      console.log('- Location provider changed: ', provider.enabled);    
-    });
+    BackgroundGeolocation.on('providerchange', this.onProviderChange);
+  }
+  componentWillUnmount() {
+    // Remove BackgroundGeolocation listeners
+    BackgroundGeolocation.un('location', this.onLocation);
+    BackgroundGeolocation.un('error', this.onError);
+    BackgroundGeolocation.un('motionchange', this.onMotionChange);
+    BackgroundGeolocation.un('activitychange', this.onActivityChange);
+    BackgroundGeolocation.un('providerchange', this.onProviderChange);
+  }
+  onLocation(location) {
+    console.log('- [js]location: ', JSON.stringify(location));
+  }
+  onError(error) {
+    var type = error.type;
+    var code = error.code;
+    alert(type + " Error: " + code);
+  }
+  onActivityChange(activityName) {
+    console.log('- Current motion activity: ', activityName);  // eg: 'on_foot', 'still', 'in_vehicle'
+  }
+  onProviderChange(provider) {
+    console.log('- Location provider changed: ', provider.enabled);    
+  }
+  onMotionChange(location) {
+    console.log('- [js]motionchanged: ', JSON.stringify(location));
   }
 });
 

--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ var Foo = React.createClass({
       stationaryRadius: 25,
       distanceFilter: 10,
       // Activity Recognition
-      stopTimeout: 1,       
+      stopTimeout: 1,
       // Application config
-      debug: true, // <-- enable this hear sounds for background-geolocation 
+      debug: true, // <-- enable this hear sounds for background-geolocation
       life-cycle.
       logLevel: BackgroundGeolocation.LOG_LEVEL_VERBOSE,
       stopOnTerminate: false,   // <-- Allow the background-service to continue tracking when user closes the app.
@@ -98,6 +98,7 @@ var Foo = React.createClass({
     // This event fires when the user toggles location-services
     BackgroundGeolocation.on('providerchange', this.onProviderChange);
   }
+  // You must remove listeners when your component unmounts
   componentWillUnmount() {
     // Remove BackgroundGeolocation listeners
     BackgroundGeolocation.un('location', this.onLocation);

--- a/RNBackgroundGeolocation.ios.js
+++ b/RNBackgroundGeolocation.ios.js
@@ -1,4 +1,4 @@
-const { React, DeviceEventEmitter} = require('react-native');
+const {DeviceEventEmitter} = require('react-native');
 const { RNBackgroundGeolocation } = require('react-native').NativeModules;
 
 const TAG = "TSLocationManager";
@@ -17,7 +17,8 @@ var API = {
     'activitychange',
     'providerchange',
     'geofenceschange',
-    'watchposition'],
+    'watchposition'
+  ],
 
   LOG_LEVEL_OFF: 0,
   LOG_LEVEL_ERROR: 1,
@@ -46,11 +47,23 @@ var API = {
     failure = failure || emptyFn;
     RNBackgroundGeolocation.getState(success, failure);
   },
-  on: function(event, callback) {
+  addListener: function(event, callback) {
     if (this.events.indexOf(event) < 0) {
       throw "RNBackgroundGeolocation: Unknown event '" + event + '"';
     }
     return DeviceEventEmitter.addListener(TAG + ':' + event, callback);
+  },
+  on: function(event, callback) {
+    this.addListener(event, callback);
+  },
+  removeListener: function(event, callback) {
+    if (this.events.indexOf(event) < 0) {
+      throw "RNBackgroundGeolocation: Unknown event '" + event + '"';
+    }
+    return DeviceEventEmitter.removeListener(TAG + ':' + event, callback);
+  },
+  un: function(event, callback) {
+    this.removeListener(event, callback);
   },
   start: function(success, failure) {
     success = success || emptyFn;
@@ -198,6 +211,7 @@ var API = {
     RNBackgroundGeolocation.getLog(success, failure);
   },
   destroyLog: function(success, failure) {
+    success = success || emptyFn;
     failure = failure || emptyFn;
     RNBackgroundGeolocation.destroyLog(success, failure);
   },

--- a/docs/README.md
+++ b/docs/README.md
@@ -105,8 +105,8 @@ bgGeo.on('location', function(location) {
 
 | Method Name | Arguments | Notes
 |---|---|---|
-| ['on'](#on-callback) | `Function` | Add an event-listener |
-| ['un'](#un-callback) | `Function` | Remove an event-listener |
+| [`on`](#oncallback) | `Function` | Add an event-listener |
+| [`un`](#uncallback) | `Function` | Remove an event-listener |
 | [`configure`](#configureobject-callback) | `{config}` | Configures the plugin's parameters (@see following Config section for accepted config params. The locationCallback will be executed each time a new Geolocation is recorded and provided with the following parameters. |
 | [`setConfig`](#setconfigobject) | `{config}` | Re-configure the plugin with new values. |
 | [`start`](#startcallbackfn) | `callbackFn`| Enable location tracking. Supplied `callbackFn` will be executed when tracking is successfully engaged. |

--- a/docs/README.md
+++ b/docs/README.md
@@ -105,6 +105,8 @@ bgGeo.on('location', function(location) {
 
 | Method Name | Arguments | Notes
 |---|---|---|
+| ['on'](#on-callback) | `Function` | Add an event-listener |
+| ['un'](#un-callback) | `Function` | Remove an event-listener |
 | [`configure`](#configureobject-callback) | `{config}` | Configures the plugin's parameters (@see following Config section for accepted config params. The locationCallback will be executed each time a new Geolocation is recorded and provided with the following parameters. |
 | [`setConfig`](#setconfigobject) | `{config}` | Re-configure the plugin with new values. |
 | [`start`](#startcallbackfn) | `callbackFn`| Enable location tracking. Supplied `callbackFn` will be executed when tracking is successfully engaged. |
@@ -661,6 +663,32 @@ bgGeo.on('schedule', function(state) {
 ```
 
 # Methods
+
+####`on(callback)`
+
+Add an event-listener
+
+```Javascript
+    componentWillMount() {
+        BackgroundGeolocation.on("location", this.onLocation);
+        .
+        .
+        .
+    }
+    onLocation(location) {
+        console.log('- Location: ', location);
+    }
+```
+
+####`un(callback)`
+
+Remove an event-listener.
+
+```Javascript
+    componentWillUnmount() {
+        BackgroundGeolocation.un("location", this.onLocation);
+    }
+```
 
 ####`configure({Object}, callback)`
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -83,9 +83,15 @@ bgGeo.setConfig({
 
 The following events can all be listened-to via the method `#on(eventName, callback)`, eg:
 ```Javascript
-bgGeo.on('location', function(location) {
+var onLocation = function(location) {
     console.log('- Location changed: ', location);
-});
+};
+bgGeo.on('location', onLocation);
+```
+
+As well as corresponding `#un` method for removing listeners:
+```Javascript
+bgGeo.un('location', onLocation);
 ```
 
 | Event Name | Notes


### PR DESCRIPTION
- [Changed] Implement a mechanism for removing listeners `removeListener` (@alias `un`).  This is particularly important for Android when using `stopOnTerminate: false`.  Listeners on `BackgroundGeolocation` should be removed in `componentDidUnmount`:
```Javascript
  componentDidMount() {
    BackgroundGeolocation.on('location', this.onLocation);
  }
  onLocation(location) {
    console.log('- Location: ', location);
  }
  componentDidUnmount() {
    BackgroundGeolocation.un('location', this.onLocation);
  }
```