### PR TITLE
`getGeofences` bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Change Log
 ## Unreleased
+- [Fixed] `getGeofences` issue #158.  `getGeofences` wasn't migrated to accept the new data-format provided by `TSLocationManager`, which now returns an `NSArray` of `NSDictionary` -- not `CLCircularRegion`.
 
 ## [1.5.2 - 2016-10-26]
 - [Added] Implement a mechanism for removing listeners `removeListener` (@alias `un`).  This is particularly important for Android when using `stopOnTerminate: false`.  Listeners on `BackgroundGeolocation` should be removed in `componentDidUnmount`:

--- a/ios/RNBackgroundGeolocation/RNBackgroundGeolocation.m
+++ b/ios/RNBackgroundGeolocation/RNBackgroundGeolocation.m
@@ -241,19 +241,9 @@ RCT_EXPORT_METHOD(sync:(RCTResponseSenderBlock)success failure:(RCTResponseSende
 RCT_EXPORT_METHOD(getGeofences:(RCTResponseSenderBlock)success failure:(RCTResponseSenderBlock)failure)
 {
     NSArray *geofences = [locationManager getGeofences];
-    NSMutableArray *rs = [NSMutableArray arrayWithCapacity:[geofences count]];
-
-    for(CLCircularRegion *geofence in geofences) {
-        NSDictionary *geofenceDictionary = @{
-            @"identifier": geofence.identifier,
-            @"radius":     [NSNumber numberWithDouble:geofence.radius],
-            @"latitude":   [NSNumber numberWithDouble:geofence.center.latitude],
-            @"longitude":  [NSNumber numberWithDouble:geofence.center.longitude]
-        };
-        [rs addObject:geofenceDictionary];
-    }
-    success(@[rs]);
+    success(@[geofences]);
 }
+
 
 RCT_EXPORT_METHOD(addGeofence:(NSDictionary*) config success:(RCTResponseSenderBlock)success failure:(RCTResponseSenderBlock)failure)
 {


### PR DESCRIPTION
`getGeofences` issue #158.  `getGeofences` wasn't migrated to accept the new data-format provided by `TSLocationManager`, which now returns an `NSArray` of `NSDictionary` -- not `CLCircularRegion`.