### PR TITLE
Remove createJSModules @override - RN 0.47 compatibility

### DIFF
--- a/android/src/main/java/com/transistorsoft/rnbackgroundgeolocation/RNBackgroundGeolocation.java
+++ b/android/src/main/java/com/transistorsoft/rnbackgroundgeolocation/RNBackgroundGeolocation.java
@@ -22,7 +22,7 @@ public class RNBackgroundGeolocation implements ReactPackage {
         return modules;
     }
 
-    // Depreciated RN 0.47
+    // Deprecated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }

--- a/android/src/main/java/com/transistorsoft/rnbackgroundgeolocation/RNBackgroundGeolocation.java
+++ b/android/src/main/java/com/transistorsoft/rnbackgroundgeolocation/RNBackgroundGeolocation.java
@@ -22,7 +22,7 @@ public class RNBackgroundGeolocation implements ReactPackage {
         return modules;
     }
 
-    @Override
+    // Depreciated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
[`createJSModules` is now not required on Android](https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8) from RN 0.47. This is required to build an app on 0.47. This is backwards compatible according to my tests.