### PR TITLE
Remove android:allowBackup attribute from AndroidManifest.xml

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.transistorsoft.rnbackgroundgeolocation">
 
-    <application android:allowBackup="true" android:label="@string/app_name"
+    <application android:label="@string/app_name"
         android:supportsRtl="true">
 
     </application>


### PR DESCRIPTION
Hi!

Can we remove `allowBackup` attribute from `AndroidManifest.xml`?
It causes conflicts when merging with manifests having `allowBackup:false`:

```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:processDebugManifest'.
> Manifest merger failed : Attribute application@allowBackup value=(false) from AndroidManifest.xml:23:9-36
        is also present at [my.app:react-native-background-geolocation:unspecified] AndroidManifest.xml:12:9-35 value=(true).
        Suggestion: add 'tools:replace="android:allowBackup"' to <application> element at AndroidManifest.xml:17:5-83:19 to override.
```

Default value for `allowBackup` is `true` anyway:
https://developer.android.com/guide/topics/manifest/application-element.html#allowbackup