### PR TITLE
Fix 'getGeofences' in README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2796,7 +2796,8 @@ Example:
 
 ```javascript
 BackgroundGeolocation.getGeofences(function(geofences) {
-  for (var n=0,len=geofences.length;n<len;n++) {
+  for (var n=0;n<geofences.length;n++) {
+    var geofence = geofences[n];
     console.log("Geofence: ", geofence.identifier, geofence.radius, geofence.latitude, geofence.longitude);
   }
 }, function(error) {


### PR DESCRIPTION
The code example for the function `getGeofences` is not runnable as-is. This corrects that.