### PR TITLE
Fix link error when iOS and npm project name are diferent

### DIFF
--- a/scripts/postlink.js
+++ b/scripts/postlink.js
@@ -8,14 +8,15 @@ const helpers = require('./xcode-helpers');
 
 const projectDirectory = process.cwd();
 const moduleDirectory = path.resolve(__dirname, '..');
-const packageManifest = require(projectDirectory + '/package.json');
+const sourceDirectory = path.join(projectDirectory, 'ios');
+const xcodeProjectDirectory = helpers.findProject(sourceDirectory);
 
 const projectConfig = {
-    sourceDir: path.join(projectDirectory, 'ios'),
+    sourceDir: sourceDirectory,
     pbxprojPath: path.join(
         projectDirectory,
         'ios',
-        packageManifest.name + '.xcodeproj',
+        xcodeProjectDirectory,
         'project.pbxproj'
     ),
 };

--- a/scripts/postunlink.js
+++ b/scripts/postunlink.js
@@ -8,14 +8,15 @@ const helpers = require('./xcode-helpers');
 
 const projectDirectory = process.cwd();
 const moduleDirectory = path.resolve(__dirname, '..');
-const packageManifest = require(projectDirectory + '/package.json');
+const sourceDirectory = path.join(projectDirectory, 'ios');
+const xcodeProjectDirectory = helpers.findProject(sourceDirectory);
 
 const projectConfig = {
-    sourceDir: path.join(projectDirectory, 'ios'),
+    sourceDir: sourceDirectory,
     pbxprojPath: path.join(
         projectDirectory,
         'ios',
-        packageManifest.name + '.xcodeproj',
+        xcodeProjectDirectory,
         'project.pbxproj'
     ),
 };


### PR DESCRIPTION
Note: This PR solves [this issue](https://github.com/transistorsoft/react-native-background-fetch/issues/63) first reported in the `react-native-background-fetch` project. A PR to fix the issue in this project already exists [here](https://github.com/transistorsoft/react-native-background-geolocation/pull/460). I have no issues with that PR, but this PR attempts to keep the code between the two projects consistent. The corresponding PR in `react-native-background-fetch` is [here](https://github.com/transistorsoft/react-native-background-fetch/pull/85).

Steps to reproduce the issue:
- Create a new react native project `react-native init BackgroundGeo`
- Add lib as dependency `npm install react-native-background-geolocation --save` or `yarn add react-native-background-geolocation`
- Change npm project name in `package.json` file from `BackgroundGeo` to `background-geo`
- Attempt to link dependency: `react-native link react-native-background-geolocation`
- Notice error messages and failure to link the library.

Steps to test PR:
- Repeat the above steps on this PR branch. The link step should succeed.