### PR TITLE
Correctly clear EVENT_SUBSCRIPTIONS in removeListeners

### DIFF
--- a/NativeModule.js
+++ b/NativeModule.js
@@ -141,7 +141,7 @@ export default class NativeModule {
         for (let n=0,len=EVENTS.length;n<len;n++) {
           EventEmitter.removeAllListeners(EVENTS[n]);
         }
-        EVENT_SUBSCRIPTIONS = [];
+        EVENT_SUBSCRIPTIONS.splice(0, EVENT_SUBSCRIPTIONS.length);
         resolve();
       }
       let failure = (error) => { reject(error) }

--- a/NativeModule.js
+++ b/NativeModule.js
@@ -65,7 +65,7 @@ const LOGGER = {
 }
 
 // Plugin event listener subscriptions
-const EVENT_SUBSCRIPTIONS = [];
+let EVENT_SUBSCRIPTIONS = [];
 
 /**
 * Native API
@@ -141,7 +141,7 @@ export default class NativeModule {
         for (let n=0,len=EVENTS.length;n<len;n++) {
           EventEmitter.removeAllListeners(EVENTS[n]);
         }
-        EVENT_SUBSCRIPTIONS.splice(0, EVENT_SUBSCRIPTIONS.length);
+        EVENT_SUBSCRIPTIONS = [];
         resolve();
       }
       let failure = (error) => { reject(error) }


### PR DESCRIPTION
EVENT_SUBSCRIPTIONS is initialized as a const which makes it a read-only variable. The previous implementation tries to re-assign the value instead of updating it which causes an error to be thrown. Also, the splice approach to clear the list has no measurable performance impact.