### PR TITLE
[RELEASE] 3.0.1.  Implement link-scripts for Android to better automate react-native link installation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [3.0.1] - 2019-04-15
+- [Added] Added android implementation for `react-native link` script to automatically add the required `maven url` and `ext.googlePlayServicesLocationVersion`.
+
+## [3.0.0]
+- [Changed] Promote `3.0.0-rc.5` to `3.0.0`.
+
 ## [3.0.0-rc.5] - 2019-03-31
 - [Fixed] Android: Another `NullPointerException` with `Bundle#getExtras`.
 

--- a/help/INSTALL-ANDROID-RNPM.md
+++ b/help/INSTALL-ANDROID-RNPM.md
@@ -20,51 +20,31 @@ react-native link cocoa-lumberjack
 
 ## Gradle Configuration
 
-react-native link does a nice job, but we need to do a bit of manual setup.
-
-### :open_file_folder: **`android/build.gradle`**
-
-Add the `googlePlayServicesLocation` Gradle variable.  This controls the version of `play-services:location` the SDK will use.
+The `react-native link` command has automatically added a new Gradle `ext` parameter **`googlePlayServicesLocationVersion`**.  You can Use this to control the version of `play-services:location` used by the Background Geolocation SDK.
 
 :information_source: You should always strive to use the latest available Google Play Services libraries.  You can determine the latest available version [here](https://developers.google.com/android/guides/setup).
+
+### :open_file_folder: **`android/build.gradle`**
 
 ```diff
 buildscript {
     ext {
++       googlePlayServicesLocationVersion = "16.0.0"
         buildToolsVersion = "28.0.3"
         minSdkVersion = 16
         compileSdkVersion = 28
         targetSdkVersion = 27
         supportLibVersion = "28.0.0"
-        // You can control the SDK's version of play-services:location
-        // You should always use the latest available version.
-+       googlePlayServicesLocationVersion = "16.0.0"
     }
     .
     .
     .
-}
-
-allprojects {
-    repositories {
-        mavenLocal()
-        google()
-        jcenter()
-        maven {
-            // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-            url "$rootDir/../node_modules/react-native/android"
-        }
-+       maven {
-+           url "$rootDir/../node_modules/react-native-background-geolocation/android/libs"
-+       }
-+       maven {
-+           url "$rootDir/../node_modules/react-native-background-fetch/android/libs"
-+       }
-    }
 }
 ```
 
 ## AndroidManifest.xml
+
+If you've **not** [purchased a license](https://www.transistorsoft.com/shop/products/react-native-background-geolocation#plans), **ignore this step** &mdash; the plugin is fully functional in *DEBUG* builds so you can try before you [buy](https://www.transistorsoft.com/shop/products/react-native-background-geolocation#plans).
 
 ```diff
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
@@ -89,6 +69,8 @@ allprojects {
 
 
 ## Proguard Config
+
+If you've enabled **`def enableProguardInReleaseBuilds = true`** in your `app/build.gradle`, be sure to add the following items to your `proguard-rules.pro`:
 
 ### :open_file_folder: `proguard-rules.pro` (`android/app/proguard-rules.pro`)
 

--- a/help/INSTALL-ANDROID.md
+++ b/help/INSTALL-ANDROID.md
@@ -74,6 +74,8 @@ The technique of **defining project-wide properties** can be found in the **Andr
 
 ## AndroidManifest.xml
 
+If you've **not** [purchased a license](https://www.transistorsoft.com/shop/products/react-native-background-geolocation#plans), **ignore this step** &mdash; the plugin is fully functional in *DEBUG* builds so you can try before you [buy](https://www.transistorsoft.com/shop/products/react-native-background-geolocation#plans).
+
 :open_file_folder: **`android/app/src/main/AndroidManifest.xml`**
 
 ```diff
@@ -119,6 +121,8 @@ public class MainApplication extends ReactApplication {
 ```
 
 ## Proguard Config
+
+If you've enabled **`def enableProguardInReleaseBuilds = true`** in your `app/build.gradle`, be sure to add the following items to your `proguard-rules.pro`:
 
 ### :open_file_folder: `proguard-rules.pro` (`android/app/proguard-rules.pro`)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-background-geolocation",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "The most sophisticated cross-platform background location-tracking & geofencing module with battery-conscious motion-detection intelligence",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -43,7 +43,7 @@
     "react-native": ">=0.36.0"
   },
   "dependencies": {
-    "react-native-background-fetch": "~2.5.2",
+    "react-native-background-fetch": "~2.5.3",
     "cocoa-lumberjack": "^3.0.5",
     "fast-plist": "^0.1.2",
     "plist": "^2.0.1",

--- a/scripts/postlink.js
+++ b/scripts/postlink.js
@@ -8,6 +8,10 @@ const helpers = require('./xcode-helpers');
 
 const projectDirectory = process.cwd();
 const moduleDirectory = path.resolve(__dirname, '..');
+
+////
+// iOS
+//
 const sourceDirectory = path.join(projectDirectory, 'ios');
 const xcodeProjectDirectory = helpers.findProject(sourceDirectory);
 
@@ -138,3 +142,116 @@ if (!plist.NSMotionUsageDescription) {
 
 helpers.writePlist(projectConfig.sourceDir, project, plist);
 fs.writeFileSync(projectConfig.pbxprojPath, project.writeSync());
+
+////
+// Android
+// 1. Add maven url
+//     maven {
+//         url "$rootDir/../node_modules/react-native-background-geolocation/android/libs"
+//     }
+// 2. Add googlePlayServicesLocationVersion ext var.
+//
+const androidSrcDir = path.join(projectDirectory, 'android');
+const projectGradleFile = path.join(androidSrcDir, 'build.gradle');
+const moduleName = moduleDirectory.split('/').pop();
+const pluginGradleFile = path.join(projectDirectory, 'node_modules', moduleName, "android", "build.gradle");
+
+const mavenUrl = [
+    '\t\tmaven {',
+    '\t\t\turl "$rootDir/../node_modules/' + moduleName + '/android/libs"',
+    '\t\t}',
+].join("\n");
+
+const repositoriesRE = new RegExp("(allprojects\\s?\\{\\n[\\s?\\t]+repositories\\s?\\{)", "gm");
+const moduleRE = new RegExp(moduleName + "\\/android", "gm");
+const extRE = new RegExp("(buildscript\\s?\\{\\n[\\t\\s]+ext\\s+\\{)", "gm");
+
+const googlePlayServicesLocationVersionRE = new RegExp("googlePlayServicesLocationVersion", "gm");
+const defaultGooglePlayServicesLocationVersionRE = new RegExp('DEFAULT_GOOGLE_PLAY_SERVICES_LOCATION_VERSION\\s+=\\s+"([0-9\\.]+)"');
+
+var googlePlayServicesLocationVersion = null;
+
+// First read DEFAULT_GOOGLE_PLAY_SERVICES_LOCATION_VERSION from plugin's build.gradle.
+try {
+    var data = fs.readFileSync(pluginGradleFile, 'utf8');
+    if (!defaultGooglePlayServicesLocationVersionRE.test(data)) {
+        return console.log("[" + moduleName + "] FAILED TO READ DEFAULT_GOOGLE_PLAY_SERVICES_LOCATION_VERSION");
+    }
+    var m = data.match(defaultGooglePlayServicesLocationVersionRE);
+    googlePlayServicesLocationVersion = m[1];
+} catch(e) {
+    console.log("[" + moduleName + "] FAILED TO OPEN FILE: " + pluginGradleFile);
+};
+
+// Open project build.gradle.  Add maven tslocationmanager maven url.
+fs.readFile(projectGradleFile, 'utf8', function (err, data) {
+  if (err) {
+    return console.log(err);
+  }
+  if (moduleRE.test(data)) {
+      return;
+  }
+  if (!repositoriesRE.test(data)) {
+      console.error("[" + moduleName + "] FAILED TO LINK MAVEN URL in android/build.gradle");
+      console.error("Ensure your android/build.gradle contains the following maven url:");
+      console.error("allprojects {\n\trepositories {\n" + mavenUrl + "\n\t}\n}");
+
+      return;
+  }
+  // Write maven url.
+  data = data.replace(repositoriesRE, "$1\n" + mavenUrl);
+
+  // Write googlePlayServicesLocationVersion
+  if ((googlePlayServicesLocationVersion != null) && extRE.test(data)) {
+      if (!googlePlayServicesLocationVersionRE.test(data)) {
+          data = data.replace(extRE, '$1\n\t\tgooglePlayServicesLocationVersion = "' + googlePlayServicesLocationVersion + '"', "gm");
+      }
+  }
+  fs.writeFile(projectGradleFile, data, 'utf8', function (err) {
+     if (err) return console.log(err);
+  });
+});
+
+// Add purge debug sounds method.
+const appGradleFile = path.join(androidSrcDir, 'app', 'build.gradle');
+const purgeMethodName = "purgeBackgroundGeolocationDebugResources";
+const purgeScript = [
+    '// [Added by react-native-background-geolocation] Purge debug sounds from release build.',
+    'def ' + purgeMethodName + '(applicationVariants) {',
+    '    if ((rootProject.ext.has("removeBackgroundGeolocationDebugSoundsInRelease")) && (rootProject.ext.removeBackgroundGeolocationDebugSoundsInRelease == false)) return',
+    '    applicationVariants.all { variant ->',
+    '        if (variant.buildType.name == "release") {',
+    '            println("[react-native-background-geolocation] Purging debug resources in release build")',
+    '            variant.mergeResources.doLast {',
+    '                delete(fileTree(dir: variant.mergeResources.outputDir, includes: ["raw_tslocationmanager*"]))',
+    '            }',
+    '        }',
+    '    }',
+    '}'
+].join("\n");
+
+fs.readFile(appGradleFile, 'utf8', function(err, data) {
+    if (err) {
+        return console.log(err);
+    }
+    var purgeMethodRE = new RegExp("^[\\s\\t]+" + purgeMethodName + "\\(applicationVariants\\)", "gm");
+
+    // Add purge-method executor if not exists.
+    if (!data.match(purgeMethodRE)) {
+        var re = /(android\s?\{\s?\n)/gm;
+        if (re.test(data)) {
+            data = data.replace(re, "$1\t" + purgeMethodName + "(applicationVariants)\n");
+        }
+    }
+    // Declare purge-method if not exists.
+    purgeMethodRE = new RegExp("^def\\s+" + purgeMethodName, "gm");
+    if (!data.match(purgeMethodRE)) {
+        data += "\n" + purgeScript;
+    }
+
+    fs.writeFile(appGradleFile, data, 'utf8', function (err) {
+        if (err) return console.log(err);
+    });
+
+});
+

--- a/scripts/postunlink.js
+++ b/scripts/postunlink.js
@@ -82,3 +82,47 @@ if (Array.isArray(plist.UIBackgroundModes)) {
 
 helpers.writePlist(projectConfig.sourceDir, project, plist);
 fs.writeFileSync(projectConfig.pbxprojPath, project.writeSync());
+
+////
+// Android
+// - Remove maven url
+//     maven {
+//         url "$rootDir/../node_modules/react-native-background-geolocation/android/libs"
+//     }
+//
+const androidSrcDir = path.join(projectDirectory, 'android');
+const gradleFile = path.join(androidSrcDir, 'build.gradle');
+const moduleName = moduleDirectory.split('/').pop();
+
+fs.readFile(gradleFile, 'utf8', function (err,data) {
+  if (err) {
+    return console.log(err);
+  }
+  var re = new RegExp("[\\t?\\s?]+maven\\s?\\{[\\n?\\s?\\t?]+url.*" + moduleName + "\\/.*[\\n?\\t?\\s?]+\\}", "gm");
+
+  if (data.match(re)) {
+      fs.writeFile(gradleFile, data.replace(re, ''), 'utf8', function (err) {
+         if (err) return console.log(err);
+      });
+  }
+
+});
+
+// Remove method-call purgeBackgroundGeolocationDebugResources(applicationVariants)
+const appGradleFile = path.join(androidSrcDir, 'app', 'build.gradle');
+const purgeMethodName = "purgeBackgroundGeolocationDebugResources";
+
+fs.readFile(appGradleFile, 'utf8', function(err, data) {
+    if (err) {
+        return console.log(err);
+    }
+    var purgeMethodRE = new RegExp("^[\\s\\t]+" + purgeMethodName + "\\(applicationVariants\\).*$[\\s\\n]+(.*)", "gm");
+
+    if (purgeMethodRE.test(data)) {
+        data = data.replace(purgeMethodRE, '\t$1');
+    }
+    fs.writeFile(appGradleFile, data, 'utf8', function (err) {
+        if (err) return console.log(err);
+    });
+});
+


### PR DESCRIPTION
Add android implementation for `react-native link` script to *automatically* add the required `maven url` in `android/build.gradle`.  Also add the `ext` var `googlePlayServicesLocationVersion`.

Android no longer requires any manual setup, other than adding your license key and proguard-config.

There are no functional changes to the SDK or Javascript API in this version.  This is pure setup script changes only.