### PR TITLE
Fixed MotionActivityEvent interface

### DIFF
--- a/src/declarations/interfaces/MotionActivityEvent.d.ts
+++ b/src/declarations/interfaces/MotionActivityEvent.d.ts
@@ -21,7 +21,7 @@ declare module "react-native-background-geolocation" {
     * | `running`      |
     * | `walking`      |
     */
-    activity: string;
+    type: string;
     /**
     * Confidence of the reported device motion activity in %.
     */


### PR DESCRIPTION
MotionActivityEvent interface has `activity` field defined but it should be `type` instead.