### PR TITLE
Fix doc to avoid Gradle error of duplicate task

### DIFF
--- a/help/INSTALL-ANDROID-AUTO.md
+++ b/help/INSTALL-ANDROID-AUTO.md
@@ -49,7 +49,6 @@ project.ext.react = [
     enableHermes: false,  // clean and rebuild if changing
 ]
 
-apply from: "../../node_modules/react-native/react.gradle"
 +apply from: "../../node_modules/react-native-background-geolocation/android/app.gradle"
 ```
 


### PR DESCRIPTION
Fix documentation to avoid `Gradle` error of duplicate task `bundle<OPTIONAL_FLAVOR><BUILD_TYPE>JsAndAssets`.

> CAUSE: `apply from: "../../node_modules/react-native/react.gradle"` did duplicate actually as error says. Remove it or just don't put it in the build.gladle of your app.