### PR TITLE
[Fixed][Xcode] Direct dependency on React-Core in podspec

### DIFF
--- a/RNBackgroundGeolocation.podspec
+++ b/RNBackgroundGeolocation.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.source              = { :git => 'https://github.com/transistorsoft/react-native-background-geolocation.git', :tag => s.version }
   s.platform            = :ios, '8.0'
 
-  s.dependency 'React'
+  s.dependency 'React-Core'
   s.static_framework = true
   s.preserve_paths      = 'docs', 'CHANGELOG.md', 'LICENSE', 'package.json', 'RNBackgroundGeolocation.ios.js'
   s.dependency 'CocoaLumberjack', '~> 3.6.1'


### PR DESCRIPTION
React is an umbrella podspec and React-Core is what iOS native modules actually want.
This did not used to matter but in the Xcode 12 build system there is something racy that causes
builds to fail sometimes if the dependency is transitive vs direct

Reference: https://github.com/facebook/react-native/issues/29633