### PR TITLE
[RELEASE] 4.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 4.4.3 &mdash; 2021-11-10
+* [Fixed][iOS] Backwards compatibility issue:  react-native@0.66 does have this method.  `No visible @interface for 'RCTEventEmitter' declares the selector 'invalidate' in RNBackgroundGeolocation.m`.  
+
 ## 4.4.2 &mdash; 2021-10-29
 * [Fixed][Android] Android 12 behaviour changes mean that foreground-services remain running.  When an Android app is terminated, the app process does not terminate (since the foreground-service is active) and `RNBackgroundGeolocationModule` remains in memory.  Given that, the plugin cannot rely on registering its event-listeners in the `RNBackgroundGeolocationModule` constructor, but must perform that task when `.ready()` is called.  This also requires resetting `mReady = false` when the `MainActivity` is destroyed, so that the next time `.ready()` is called, the event-listeners are re-registered.
 * [Fixed][Android] When `.ready()` is called __`reset: false`__, the `success` callback was not invoked with the current `State`.  This bug was introduced in previous `v4.4.1`.

--- a/ios/RNBackgroundGeolocation/RNBackgroundGeolocation.m
+++ b/ios/RNBackgroundGeolocation/RNBackgroundGeolocation.m
@@ -661,7 +661,12 @@ RCT_EXPORT_METHOD(playSound:(int)soundId)
 
 - (void)invalidate
 {
-    [super invalidate];
+    // [super invalidate] if exists.
+    // https://github.com/transistorsoft/react-native-background-geolocation/issues/1407
+    if([super respondsToSelector:@selector(invalidate)]){
+        [super performSelector:@selector(invalidate)];
+    }
+    
     [locationManager removeListeners];
     dispatch_async(dispatch_get_main_queue(), ^{
         [self.locationManager stopWatchPosition];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-background-geolocation",
-  "version": "4.4.2",
+  "version": "4.4.3",
   "description": "The most sophisticated cross-platform background location-tracking & geofencing module with battery-conscious motion-detection intelligence",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
## 4.4.3 &mdash; 2021-11-10
* [Fixed][iOS] Backwards compatibility issue:  react-native@0.66 does have this method.  `No visible @interface for 'RCTEventEmitter' declares the selector 'invalidate' in RNBackgroundGeolocation.m`.  