### PR TITLE
Update iOS auto-linking docs

### DIFF
--- a/help/INSTALL-IOS-AUTO.md
+++ b/help/INSTALL-IOS-AUTO.md
@@ -72,6 +72,6 @@ Edit **`Info.plist`**.  Add the following items (Set **Value** as desired):
 ![](https://dl.dropboxusercontent.com/s/j7udsab7brlj4yk/Screenshot%202016-09-22%2008.33.53.png?dl=1)
 
 
-## [Configure `react-native-background-fetch`](https://github.com/transistorsoft/react-native-background-fetch/blob/master/docs/INSTALL-AUTO-IOS.md#configure-background-capabilities)
+## [Configure `react-native-background-fetch`](https://github.com/transistorsoft/react-native-background-fetch/blob/master/docs/INSTALL-AUTO-IOS.md#ios-auto-linking-setup)
 
-The BackgroundGeolocation SDK makes use internally on __`react-native-background-fetch`__.  Regardless of whether you instend to implement the BackgroundFetch Javascript API in your app, you **must** perform the [Background Fetch iOS Setup](https://github.com/transistorsoft/react-native-background-fetch/blob/master/docs/INSTALL-AUTO-IOS.md#configure-background-capabilities) at __`react-native-background-fetch`__.
+The BackgroundGeolocation SDK makes use internally on __`react-native-background-fetch`__.  Regardless of whether you intend to implement the BackgroundFetch Javascript API in your app, you **must** perform the [Background Fetch iOS Setup](https://github.com/transistorsoft/react-native-background-fetch/blob/master/docs/INSTALL-AUTO-IOS.md#configure-background-capabilities) at __`react-native-background-fetch`__.


### PR DESCRIPTION
## Background Fetch linking
When following the docs verbatim, the `react-native-background-fetch` install will be skipped because the docs link directly to the [**Configure Background Capabilities**](https://github.com/transistorsoft/react-native-background-fetch/blob/master/docs/INSTALL-AUTO-IOS.md#configure-background-capabilities) section. Building the app will fail until previous yarn/pod install steps are also completed. This may seem obvious but could be a hurdle for less experienced developers. 


https://user-images.githubusercontent.com/1770862/144085134-2c257464-5786-4225-a756-85415c521b31.mp4



Also includes a simple spelling correction. 