### PR TITLE
Add a note about problematic googlePlayServicesLocationVersion

### DIFF
--- a/help/INSTALL-ANDROID-AUTO.md
+++ b/help/INSTALL-ANDROID-AUTO.md
@@ -65,7 +65,7 @@ buildscript {
         targetSdkVersion = 31           // Or higher.
 +       compileSdkVersion = 31          // Or higher.
 +       appCompatVersion = "1.1.0"      // Or higher.  Required for new AndroidX compatibility.
-+       googlePlayServicesLocationVersion = "19.0.1"  // Or higher.
++       googlePlayServicesLocationVersion = "19.0.1"  // Or higher, but avoid "21.0.0" as it is known to crash.
     }
     ...
 }


### PR DESCRIPTION
Change comment next to googlePlayServicesLocationVersion, with a remark about version "21.0.0" being known to crash the app running react-native-background-geolocation.