### PR TITLE
fix(motion-activity-event): correct field name and update to union type

### DIFF
--- a/src/declarations/interfaces/Location.d.ts
+++ b/src/declarations/interfaces/Location.d.ts
@@ -1,5 +1,5 @@
 /// <reference path="./GeofenceEvent.d.ts" />
-/// <reference path="./MotionActivityEvent.d.ts" />
+/// <reference path="./LocationMotionActivityEvent.d.ts" />
 /// <reference path="./ProviderChangeEvent.d.ts" />
 /// <reference path="../types.d.ts" />
 ///
@@ -216,7 +216,7 @@ declare module "react-native-background-geolocation" {
     /**
     * Device motion-activity when this location was recorded (eg: `still`, `on_foot`, `in_vehicle`).
     */
-    activity: MotionActivityEvent;
+    activity: LocationMotionActivityEvent;
     /**
     * If this location was recorded due to [[ProviderChangeEvent]], this is a reference to the location-provider state.
     */

--- a/src/declarations/interfaces/LocationMotionActivityEvent.d.ts
+++ b/src/declarations/interfaces/LocationMotionActivityEvent.d.ts
@@ -1,0 +1,42 @@
+declare module "react-native-background-geolocation" {
+  /**
+   * Type of activity.
+   */
+  type LocationMotionActivityType =
+    | "still"
+    | "walking"
+    | "on_foot"
+    | "running"
+    | "on_bicycle"
+    | "in_vehicle";
+
+  /**
+   * The `activity` field which is part of the `Location` type that gets passed to [[BackgroundGeolocation.onLocation]].
+   *
+   * @example
+   * ```typescript
+   * BackgroundGeolocation.onLocatione(location => {
+   *   console.log("[location] ", location.activity.type, location.activity.confidence);
+   * });
+   * ```
+   */
+  interface LocationMotionActivityEvent {
+    /**
+     * The reported device motion activity.
+     *
+     * | Activity Name  |
+     * |----------------|
+     * | `still`        |
+     * | `walking`      |
+     * | `on_foot`      |
+     * | `running`      |
+     * | `on_bicycle`   |
+     * | `in_vehicle`   |
+     */
+    type: LocationMotionActivityType;
+    /**
+     * Confidence of the reported device motion activity in %.
+     */
+    confidence: number;
+  }
+}

--- a/src/declarations/interfaces/MotionActivityEvent.d.ts
+++ b/src/declarations/interfaces/MotionActivityEvent.d.ts
@@ -1,16 +1,5 @@
 declare module "react-native-background-geolocation" {
   /**
-   * Type of activity.
-   */
-  type MotionActivityType =
-    | "still"
-    | "walking"
-    | "on_foot"
-    | "running"
-    | "on_bicycle"
-    | "in_vehicle";
-
-  /**
    * The event-object provided to [[BackgroundGeolocation.onActivityChange]].  Also attached to each recorded [[Location]].
    *
    * @example
@@ -33,7 +22,7 @@ declare module "react-native-background-geolocation" {
      * | `on_bicycle`   |
      * | `in_vehicle`   |
      */
-    type: MotionActivityType;
+    activity: string;
     /**
      * Confidence of the reported device motion activity in %.
      */

--- a/src/declarations/interfaces/MotionActivityEvent.d.ts
+++ b/src/declarations/interfaces/MotionActivityEvent.d.ts
@@ -1,31 +1,42 @@
 declare module "react-native-background-geolocation" {
   /**
-  * The event-object provided to [[BackgroundGeolocation.onActivityChange]].  Also attached to each recorded [[Location]].
-  *
-  * @example
-  * ```typescript
-  * BackgroundGeolocation.onActivityChange(activityChangeEvent => {
-  *   console.log("[activitychange] ", activityChangeEvent.activity, activityChangeEvent.confidence);
-  * });
-  * ```
-  */
+   * Type of activity.
+   */
+  type MotionActivityType =
+    | "still"
+    | "walking"
+    | "on_foot"
+    | "running"
+    | "on_bicycle"
+    | "in_vehicle";
+
+  /**
+   * The event-object provided to [[BackgroundGeolocation.onActivityChange]].  Also attached to each recorded [[Location]].
+   *
+   * @example
+   * ```typescript
+   * BackgroundGeolocation.onActivityChange(activityChangeEvent => {
+   *   console.log("[activitychange] ", activityChangeEvent.activity, activityChangeEvent.confidence);
+   * });
+   * ```
+   */
   interface MotionActivityEvent {
     /**
-    * The reported device motion activity.
-    *
-    * | Activity Name  |
-    * |----------------|
-    * | `still`        |
-    * | `walking`      |
-    * | `on_foot`      |
-    * | `running`      |
-    * | `on_bicycle`   |
-    * | `in_vehicle`   |
-    */
-    activity: string;
+     * The reported device motion activity.
+     *
+     * | Activity Name  |
+     * |----------------|
+     * | `still`        |
+     * | `walking`      |
+     * | `on_foot`      |
+     * | `running`      |
+     * | `on_bicycle`   |
+     * | `in_vehicle`   |
+     */
+    type: MotionActivityType;
     /**
-    * Confidence of the reported device motion activity in %.
-    */
+     * Confidence of the reported device motion activity in %.
+     */
     confidence: number;
   }
 }


### PR DESCRIPTION
- Allows developers using TypeScript the ability to access the activity type using the correct field name. 
- Gives better code completion feedback.

Resolves #1523