### PR TITLE
Support for monorepos

### DIFF
--- a/expo/plugin/src/androidPlugin.ts
+++ b/expo/plugin/src/androidPlugin.ts
@@ -33,6 +33,9 @@ const findModuleRecursively = (dir: string): string | null => {
   if (fs.existsSync(path.join(nodeModules, PUBLIC_MODULE))) {
     return PUBLIC_MODULE;
   }
+  if (fs.existsSync(path.join(nodeModules, PRIVATE_MODULE))) {
+    return PRIVATE_MODULE;
+  }
 
   const parent = path.resolve(dir, '..');
   if (parent === dir) {
@@ -42,7 +45,11 @@ const findModuleRecursively = (dir: string): string | null => {
 
   return findModuleRecursively(parent);
 };
-const MODULE_NAME = findModuleRecursively(path.resolve('.')) || PRIVATE_MODULE;
+const MODULE_NAME = findModuleRecursively(path.resolve('.'));
+if (!MODULE_NAME) {
+  console.error(`Could not find neither '${PUBLIC_MODULE}' or '${PRIVATE_MODULE}' in node_modules`);
+  process.exit(1);
+}
 
 const { addMetaDataItemToMainApplication, getMainApplicationOrThrow } = AndroidConfig.Manifest;
 

--- a/expo/plugin/src/androidPlugin.ts
+++ b/expo/plugin/src/androidPlugin.ts
@@ -24,12 +24,25 @@ import fs from 'fs';
 
 const PUBLIC_MODULE = 'react-native-background-geolocation';
 const PRIVATE_MODULE = PUBLIC_MODULE + '-android';
-const NODE_MODULES = path.join('.', 'node_modules');
 
 const META_LICENSE_KEY = "com.transistorsoft.locationmanager.license";
 const META_HMS_LICENSE_KEY = "com.transistorsoft.locationmanager.hms.license";
 
-const MODULE_NAME = fs.existsSync(path.join(NODE_MODULES, PUBLIC_MODULE)) ? PUBLIC_MODULE : PRIVATE_MODULE;
+const findModuleRecursively = (dir: string): string | null => {
+  const nodeModules = path.resolve(dir, 'node_modules');
+  if (fs.existsSync(path.join(nodeModules, PUBLIC_MODULE))) {
+    return PUBLIC_MODULE;
+  }
+
+  const parent = path.resolve(dir, '..');
+  if (parent === dir) {
+    // we have reached the root of the file system -> not found
+    return null;
+  }
+
+  return findModuleRecursively(parent);
+};
+const MODULE_NAME = findModuleRecursively(path.resolve('.')) || PRIVATE_MODULE;
 
 const { addMetaDataItemToMainApplication, getMainApplicationOrThrow } = AndroidConfig.Manifest;
 


### PR DESCRIPTION
When running the React Native or Expo inside a monorepo the `node_modules` folder is not located in the same folder as the project's `package.json` but a few levels above at the monorepo's root. This PR recursively searches through all `node_module`s until it can find `react-native-background-geolocation`. If it is not found then it falls back to `PRIVATE_MODULE` as before.