### PR TITLE
Fix typing for `registerHeadlessTask` callback

### DIFF
--- a/src/declarations/BackgroundGeolocation.d.ts
+++ b/src/declarations/BackgroundGeolocation.d.ts
@@ -673,6 +673,7 @@ declare module "react-native-background-geolocation" {
     *
     * ### ⚠️ Warning:
     * - You __must__ `registerHeadlessTask` in your application root file (eg: `index.js`).
+    * - The `callback` __needs__ to return a Promise, otherwise it might crash the application.
     *
     * @example
     * ```typescript
@@ -699,7 +700,7 @@ declare module "react-native-background-geolocation" {
     * - 📘 [Android Headless Mode](github:wiki/Android-Headless-Mode).
     *
     */
-    static registerHeadlessTask(callback:(event:Object)=>any): void;
+    static registerHeadlessTask(callback: (event:Object) => Promise<any>): void;
 
     /**
     *


### PR DESCRIPTION
The callback needs to return a promise that is used by React Native's TaskProvider:

```ts
type Task = (taskData: any) => Promise<void>;
type TaskProvider = () => Task;
```