### PR TITLE
Fixed 4.14.1 released date on Changelog.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ duct flavors.
 ## 4.14.2 &mdash; 2023-10-05
 * [Android] `getGeofence` / `getGeofences` not returning new `Geofence.vertices` property.
 
-## 4.14.1 &mdash; 2012-10-02
+## 4.14.1 &mdash; 2023-10-03
 * [iOS] Fix "*Duplicate symbol error DummyPods_TSLocationManager*".
 * [Android] Fix timeout issue in `.watchPosition`.
 


### PR DESCRIPTION
Was checking changelog and saw 4.14.1 released on 2012, seemed like typo so fixed it from released tag date https://github.com/transistorsoft/react-native-background-geolocation/releases/tag/4.14.1