### PR TITLE
Fix file path for doc links in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug.yml
@@ -11,7 +11,7 @@ body:
     id: terms
     attributes:
       label: Required Reading
-      description: "- I have read the Wikis [Philosophy of Operation](../wiki/Philosophy-of-Operation) and [Debugging](../wiki/Debugging)\n- I am aware of the [API Documentation](https://transistorsoft.github.io/react-native-background-geolocation/)\n- I am aware of the [CHANGELOG](../blob/master/CHANGELOG.md)"
+      description: "- I have read the Wikis [Philosophy of Operation](./wiki/Philosophy-of-Operation) and [Debugging](./wiki/Debugging)\n- I am aware of the [API Documentation](https://transistorsoft.github.io/react-native-background-geolocation/)\n- I am aware of the [CHANGELOG](./blob/master/CHANGELOG.md)"
       options:
         - label: Confirmed
           required: true

--- a/.github/ISSUE_TEMPLATE/2-help-wanted.yml
+++ b/.github/ISSUE_TEMPLATE/2-help-wanted.yml
@@ -11,7 +11,7 @@ body:
     id: terms
     attributes:
       label: Required Reading
-      description: "- I have read the Wikis [Philosophy of Operation](../wiki/Philosophy-of-Operation) and [Debugging](../wiki/Debugging)\n- I am aware of the [API Documentation](https://transistorsoft.github.io/react-native-background-geolocation/)\n- I am aware of the [CHANGELOG](../blob/master/CHANGELOG.md)"
+      description: "- I have read the Wikis [Philosophy of Operation](./wiki/Philosophy-of-Operation) and [Debugging](./wiki/Debugging)\n- I am aware of the [API Documentation](https://transistorsoft.github.io/react-native-background-geolocation/)\n- I am aware of the [CHANGELOG](./blob/master/CHANGELOG.md)"
       options:
         - label: Confirmed
           required: true


### PR DESCRIPTION
I was going to open an issue for an unrelated matter and saw that the current links within the issue templates result in a 404. 

Loading the issue templates from my fork with these changes, the new links correctly include the project name in the url path.

### Example
  - Previous: `github.com/transistorsoft/blob/master/CHANGELOG.md`
  - With fix: `github.com/transistorsoft/react-native-background-geolocation/blob/master/CHANGELOG.md`