### PR TITLE
[Android] Fix headless NPE: guard null ReactContext in HeadlessTaskManager.startTask (New Arch / bridgeless)

### DIFF
--- a/android/src/main/java/com/transistorsoft/rnbackgroundgeolocation/HeadlessTaskManager.java
+++ b/android/src/main/java/com/transistorsoft/rnbackgroundgeolocation/HeadlessTaskManager.java
@@ -102,10 +102,18 @@ public class HeadlessTaskManager implements HeadlessJsTaskEventListener {
 
         addTask(task);
 
-        if (!mIsReactContextInitialized.get()) {
+        // Re-resolve the *live* ReactContext rather than trusting the sticky
+        // mIsReactContextInitialized flag (never reset on teardown). On the New
+        // Architecture the headless ReactContext is torn down after a task finishes,
+        // so getReactContext() returns null while the flag stays true; passing that
+        // null to HeadlessJsTaskContext.getInstance(@NonNull) throws an NPE and drops
+        // the event. Mirrors react-native-background-fetch's null-guard.
+        ReactContext reactContext = mIsReactContextInitialized.get() ? getReactContext(context) : null;
+        if (reactContext == null) {
+            mIsReactContextInitialized.set(false);
             createReactContextAndScheduleTask(context);
         } else {
-            boolean success = invokeStartTask(getReactContext(context), task);
+            boolean success = invokeStartTask(reactContext, task);
             if (!success) {
                 removeTask(task);
             }


### PR DESCRIPTION
## Summary
On the New Architecture (bridgeless), terminated-app headless `location` events can be **silently dropped before the JS headless task runs**, via an uncaught `HeadlessJsTaskContext.getInstance(null)` NullPointerException thrown inside `HeadlessTaskManager.startTask`. Because the crash happens before any JS runs, the app never sees the event — a silent location-data loss on the "buffer every observation" path.

Reproduced on a real device (Samsung Galaxy A17 5G, Android 16) with RN 0.85.3 / Expo SDK 56, New Architecture enabled, `enableHeadless: true`, `stopOnTerminate: false`. Present back to `4.18.1`, and still present on `master` — verified 2026-07-30 against `b60a9863` (5.4.0): `startTask` is byte-identical to `5.1.1`, and this patch applies cleanly to that commit.

```
java.lang.NullPointerException: Parameter specified as non-null is null:
  method com.facebook.react.jstasks.HeadlessJsTaskContext$Companion.getInstance, parameter context
    at com.facebook.react.jstasks.HeadlessJsTaskContext$Companion.getInstance(HeadlessJsTaskContext.kt)
    at com.transistorsoft.rnbackgroundgeolocation.HeadlessTaskManager.invokeStartTask(HeadlessTaskManager.java:136)
    at com.transistorsoft.rnbackgroundgeolocation.HeadlessTaskManager.startTask(HeadlessTaskManager.java:108)
    at com.transistorsoft.rnbackgroundgeolocation.HeadlessTask.onHeadlessEvent(HeadlessTask.java:96)
```

(Line numbers above are `5.1.1`. On `master`, `HeadlessTaskManager.java` is unchanged — `startTask:105-113`, `invokeStartTask:136` — and the `HeadlessTask.java` call site is `:98`.)

## Root cause
`startTask` branches on the sticky `mIsReactContextInitialized` flag, which is set once and never reset on teardown. On bridgeless, after a prior headless task finishes the headless `ReactContext` is torn down; the flag still reads `true`, so the `else` branch runs and `getReactContext()` (reflection: `getReactHost()` → `getCurrentReactContext()`) now returns `null`. That `null` is passed to `HeadlessJsTaskContext.getInstance(reactContext)` (line 136, non-null Kotlin param) → NPE.

The first-event / not-yet-initialised case is safe — it takes the `if` branch (`createReactContextAndScheduleTask`, which queues and drains). The bug is specifically the `else` fast-path trusting the stale flag. (The file null-guards `createReactContextAndScheduleTask` and `finishTask`, but not this path.)

## Fix
Re-resolve the live `ReactContext` and route `null` into the existing queue/re-init path instead of trusting the flag (the task is already enqueued via `addTask` and drains once the context re-initialises). This mirrors the null-guard already in `react-native-background-fetch`'s `HeadlessTask` (`HeadlessTask.java:55-65`), which resolves the context first and branches on `reactContext == null`; the geolocation `4.18.1` "Introduce HeadlessTaskManager" refactor dropped that shape in favour of the flag.

```java
public void startTask(Context context, Task task) throws AssertionError {
    UiThreadUtil.assertOnUiThread();

    addTask(task);

    // Re-resolve the *live* ReactContext rather than trusting the sticky
    // mIsReactContextInitialized flag (never reset on teardown). On the New
    // Architecture the headless ReactContext is torn down after a task finishes,
    // so getReactContext() returns null while the flag stays true; passing that
    // null to HeadlessJsTaskContext.getInstance(@NonNull) throws an NPE and drops
    // the event. Mirrors react-native-background-fetch's null-guard.
    ReactContext reactContext = mIsReactContextInitialized.get() ? getReactContext(context) : null;
    if (reactContext == null) {
        mIsReactContextInitialized.set(false);
        createReactContextAndScheduleTask(context);
    } else {
        boolean success = invokeStartTask(reactContext, task);
        if (!success) {
            removeTask(task);
        }
    }
}
```

## Testing
Verified by a terminated-app walk: with `persistMode: All`, the SDK persists every location natively *before* the JS dispatch this NPE aborts, so `getCount()` / `getLocations()` gives a ground-truth emitted count. Comparing that against what the headless task actually received showed the gap before the fix (events lost in the post-teardown window) and no gap after.

The patch also compiles clean (`gradlew :react-native-background-geolocation:compileDebugJavaWithJavac`; `ReactContext` was already imported, and the only javac note — a deprecated-API warning on this file — is pre-existing and unchanged).

No unit test is included — the Android module currently has no `src/test` harness. Happy to add a Robolectric test (driving `startTask` with the sticky-flag-`true` + null-current-context condition) if you'd like one.
